### PR TITLE
Make `Lockable` and `Unlockable` private

### DIFF
--- a/hal/src/common/thumbv7em/clock/v2/gclk.rs
+++ b/hal/src/common/thumbv7em/clock/v2/gclk.rs
@@ -12,7 +12,10 @@ pub use crate::pac::gclk::{GENCTRL, RegisterBlock};
 pub use crate::pac::gclk::genctrl::SRC_A as GclkSourceEnum;
 
 use crate::time::Hertz;
-use crate::typelevel::{Count, Increment, Decrement, Lockable, Unlockable, Is, Sealed, Zero, One};
+use crate::typelevel::{
+    Count, Decrement, Increment, Is, Lockable, One, Sealed, SealedLockable, SealedUnlockable,
+    Unlockable, Zero,
+};
 
 use super::sources::dfll::Fll;
 
@@ -429,7 +432,7 @@ where
 // Lockable
 //==============================================================================
 
-impl<G, T, N> Lockable for Gclk<G, T, N>
+impl<G, T, N> SealedLockable for Gclk<G, T, N>
 where
     G: GenNum,
     T: GclkSourceType,
@@ -441,11 +444,19 @@ where
     }
 }
 
+impl<G, T, N> Lockable for Gclk<G, T, N>
+where
+    G: GenNum,
+    T: GclkSourceType,
+    N: Increment,
+{
+}
+
 //==============================================================================
 // Unlockable
 //==============================================================================
 
-impl<G, T, N> Unlockable for Gclk<G, T, N>
+impl<G, T, N> SealedUnlockable for Gclk<G, T, N>
 where
     G: GenNum,
     T: GclkSourceType,
@@ -455,6 +466,14 @@ where
     fn unlock(self) -> Self::Unlocked {
         Gclk::create(self.config, self.count.dec())
     }
+}
+
+impl<G, T, N> Unlockable for Gclk<G, T, N>
+where
+    G: GenNum,
+    T: GclkSourceType,
+    N: Decrement,
+{
 }
 
 //==============================================================================
@@ -473,7 +492,6 @@ seq!(G in 0..=11 {
 impl GclkSourceType for Gen1 {
     const GCLK_SRC: GclkSourceEnum = GclkSourceEnum::GCLKGEN1;
 }
-
 
 macro_rules! impl_gclk1_source {
     ($GenNum:ident) => {

--- a/hal/src/common/thumbv7em/clock/v2/sources/dfll.rs
+++ b/hal/src/common/thumbv7em/clock/v2/sources/dfll.rs
@@ -1,7 +1,10 @@
 use crate::pac::oscctrl::RegisterBlock;
 
 use crate::time::{Hertz, U32Ext};
-use crate::typelevel::{Lockable, Unlockable, Increment, Decrement, Count, Zero, One, Sealed};
+use crate::typelevel::{
+    Count, Decrement, Increment, Lockable, One, Sealed, SealedLockable, SealedUnlockable,
+    Unlockable, Zero,
+};
 
 use super::super::gclk::{GenNum, GclkSourceEnum, GclkSource, GclkSourceType};
 
@@ -49,12 +52,11 @@ impl Dfll<One> {
 
 impl<N: Count> Sealed for Dfll<N> {}
 
-
 //==============================================================================
 // Lockable
 //==============================================================================
 
-impl<N> Lockable for Dfll<N>
+impl<N> SealedLockable for Dfll<N>
 where
     N: Increment,
 {
@@ -66,11 +68,13 @@ where
     }
 }
 
+impl<N> Lockable for Dfll<N> where N: Increment {}
+
 //==============================================================================
 // Unlockable
 //==============================================================================
 
-impl<N> Unlockable for Dfll<N>
+impl<N> SealedUnlockable for Dfll<N>
 where
     N: Decrement,
 {
@@ -81,6 +85,8 @@ where
         Dfll { regs, count }
     }
 }
+
+impl<N> Unlockable for Dfll<N> where N: Decrement {}
 
 //==============================================================================
 // GclkSource

--- a/hal/src/common/thumbv7em/clock/v2/sources/dpll.rs
+++ b/hal/src/common/thumbv7em/clock/v2/sources/dpll.rs
@@ -7,8 +7,11 @@ use crate::pac::oscctrl::DPLL;
 
 pub use crate::pac::oscctrl::dpll::dpllctrlb::REFCLK_A as DpllSrc;
 
-use crate::time::{Hertz};
-use crate::typelevel::{Sealed, Count, Zero, Increment, Decrement, Lockable, Unlockable};
+use crate::time::Hertz;
+use crate::typelevel::{
+    Count, Decrement, Increment, Lockable, Sealed, SealedLockable, SealedUnlockable, Unlockable,
+    Zero,
+};
 
 use super::super::gclk::{GenNum, GclkSourceEnum, GclkSource, GclkSourceType};
 use super::super::pclk::{Pclk, PclkType, PclkSourceType};
@@ -417,7 +420,7 @@ where
 // Lockable
 //==============================================================================
 
-impl<D, T, N> Lockable for Dpll<D, T, N>
+impl<D, T, N> SealedLockable for Dpll<D, T, N>
 where
     D: DpllNum,
     T: DpllSourceType,
@@ -429,11 +432,19 @@ where
     }
 }
 
+impl<D, T, N> Lockable for Dpll<D, T, N>
+where
+    D: DpllNum,
+    T: DpllSourceType,
+    N: Increment,
+{
+}
+
 //==============================================================================
 // Unlockable
 //==============================================================================
 
-impl<D, T, N> Unlockable for Dpll<D, T, N>
+impl<D, T, N> SealedUnlockable for Dpll<D, T, N>
 where
     D: DpllNum,
     T: DpllSourceType,
@@ -443,6 +454,14 @@ where
     fn unlock(self) -> Self::Unlocked {
         Dpll::create(self.config, self.count.dec())
     }
+}
+
+impl<D, T, N> Unlockable for Dpll<D, T, N>
+where
+    D: DpllNum,
+    T: DpllSourceType,
+    N: Decrement,
+{
 }
 
 //==============================================================================

--- a/hal/src/common/thumbv7em/clock/v2/sources/gclkio.rs
+++ b/hal/src/common/thumbv7em/clock/v2/sources/gclkio.rs
@@ -124,7 +124,7 @@ where
 // Lockable
 //==============================================================================
 
-impl<G, I, N> Lockable for GclkIn<G, I, N>
+impl<G, I, N> SealedLockable for GclkIn<G, I, N>
 where
     G: GenNum,
     I: GclkIo<G>,
@@ -138,11 +138,19 @@ where
     }
 }
 
+impl<G, I, N> Lockable for GclkIn<G, I, N>
+where
+    G: GenNum,
+    I: GclkIo<G>,
+    N: Increment,
+{
+}
+
 //==============================================================================
 // Unlockable
 //==============================================================================
 
-impl<G, I, N> Unlockable for GclkIn<G, I, N>
+impl<G, I, N> SealedUnlockable for GclkIn<G, I, N>
 where
     G: GenNum,
     I: GclkIo<G>,
@@ -154,6 +162,14 @@ where
         let count = count.dec();
         GclkIn { token, pin, freq, count }
     }
+}
+
+impl<G, I, N> Unlockable for GclkIn<G, I, N>
+where
+    G: GenNum,
+    I: GclkIo<G>,
+    N: Decrement,
+{
 }
 
 //==============================================================================

--- a/hal/src/typelevel.rs
+++ b/hal/src/typelevel.rs
@@ -9,9 +9,27 @@ mod private {
     /// Super trait used to mark traits with an exhaustive set of
     /// implementations
     pub trait Sealed {}
+
+    pub trait Lockable {
+        type Locked;
+        fn lock(self) -> Self::Locked;
+    }
+
+    pub trait Unlockable {
+        type Unlocked;
+        fn unlock(self) -> Self::Unlocked;
+    }
 }
 
+pub(crate) use private::Lockable as SealedLockable;
 pub(crate) use private::Sealed;
+pub(crate) use private::Unlockable as SealedUnlockable;
+
+/// TODO
+pub trait Lockable: SealedLockable {}
+
+/// TODO
+pub trait Unlockable: SealedUnlockable {}
 
 /// Type-level version of the [`None`] variant
 pub struct NoneT;
@@ -152,21 +170,3 @@ pub trait GreaterThanOne {}
 impl<U: Unsigned, X: Bit, Y: Bit> GreaterThanOne for UInt<UInt<U, X>, Y> {}
 
 impl<N: Unsigned + GreaterThanOne> GreaterThanOne for Natural<N> {}
-
-//==============================================================================
-// Lockable
-//==============================================================================
-
-pub trait Lockable {
-    type Locked;
-    fn lock(self) -> Self::Locked;
-}
-
-//==============================================================================
-// Unlockable
-//==============================================================================
-
-pub trait Unlockable {
-    type Unlocked;
-    fn unlock(self) -> Self::Unlocked;
-}


### PR DESCRIPTION
Now, `Lockable` and `Unlockable` traits are unimportable by a crate user
making methods `lock()` and `unlock()` uncallable.